### PR TITLE
Supporting pending skiplist

### DIFF
--- a/multi_skiplist.c
+++ b/multi_skiplist.c
@@ -456,7 +456,8 @@ int multi_skiplist_to_array(MultiSkiplist *sl, void *array_buf) {
     Skiplist_Entry *buf = (Skiplist_Entry *)array_buf;
     int total_write = 0;
 
-    // printk("multi_skiplist_to_array() start");
+    printk("multi_skiplist_to_array() start, sl: %px, buf: %px\n", sl, array_buf);
+    printk("sl->top: %px\n", sl->top);
     cursor = sl->top->links[0];
     while(cursor != sl->tail) {
         buf[total_write] = *((Skiplist_Entry *)cursor->head->data);
@@ -464,6 +465,6 @@ int multi_skiplist_to_array(MultiSkiplist *sl, void *array_buf) {
         total_write++;
     }
 
-    // printk("multi_skiplist_to_array() end: wrote %d bytes\n", total_write * sizeof(Skiplist_Entry));
+    printk("multi_skiplist_to_array() end: wrote %d bytes\n", total_write * sizeof(Skiplist_Entry));
     return total_write * sizeof(Skiplist_Entry);
 }

--- a/skiplist_api.c
+++ b/skiplist_api.c
@@ -11,18 +11,28 @@ int sl_max_level;
 MultiSkiplist *global_skiplist;
 int cur_entry_num, flush_count;
 BlockAddressNode *flushed_head;
-ThreadNode *kthread_head;
+// ThreadNode *kthread_head;
 struct mutex check_lock;
 
+/*
+ * Superblock information object from the F2FS node manager initialization.
+ * We only have this single instance which means we only support for single
+ * mount file system for now.
+ */
 
-static const char *f2fs_kv_entry_to_string(void *data, char *buff, const int size) {
+void f2fs_kv_flush(void *s, void *arr, int size, unsigned int *blkaddr);
+void f2fs_kv_read(struct page *page, void *s, unsigned int blkaddr);
+static struct f2fs_sb_info *sbi;
+
+
+const char *f2fs_kv_entry_to_string(void *data, char *buff, const int size) {
     Skiplist_Entry *entry = (Skiplist_Entry *)data;
     snprintf(buff, 1024, "NodeID: %d {INO: %d, BLK_ADDR: %px, Ver: %d}", 
         entry->nid, entry->nat_entry.ino, entry->nat_entry.block_addr, entry->nat_entry.version);
     return buff;
 }
 
-static int f2fs_kv_compare_func(const void *p1, const void *p2) {
+int f2fs_kv_compare_func(const void *p1, const void *p2) {
     // NAT_Entry *e1 = (NAT_Entry *)p1;
     // NAT_Entry *e2 = (NAT_Entry *)p2;
     // F2FS_NAT_Entry *e1 = (F2FS_NAT_Entry *)p1;
@@ -33,23 +43,32 @@ static int f2fs_kv_compare_func(const void *p1, const void *p2) {
     return e1->nid - e2->nid;
 }
 
-static void f2fs_kv_free_func(void *ptr) {
+void f2fs_kv_free_func(void *ptr) {
     kfree(ptr);
 }
 
-static int f2fs_kv_flush_thread(void *arg) {
-    MultiSkiplist *sl = ((ThreadArgs *)arg)->sl;
-    ThreadNode *my_node = ((ThreadArgs *)arg)->node;
-    ThreadNode *tnode_it;
+int f2fs_kv_flush_thread(void *arg) {
+    MultiSkiplist *sl = ((MultiSkiplist *)arg);
+    // ThreadNode *my_node = ((ThreadArgs *)arg)->node;
+    // ThreadNode *tnode_it;
     BlockAddressNode *node;
-    void *blk_addr = NULL; // Block address returned by I/O
+    u32 blkaddr;
     int arr_size = 0;
-    void *array = kmalloc(DATA_ARRAY_SIZE, GFP_KERNEL);
+    int nr_pages = max(DATA_ARRAY_SIZE / PAGE_SIZE, 1);
+    struct page *page;
+    void *array;
 #ifdef _SKIPLIST_API_DEBUG
     Skiplist_Entry tmp_entry;
-    int i;
 #endif
-    // printk("Entered flush thread\n");
+    printk("Entered flush thread, array: %px / sl=%px\n", array, sl);
+    // printk("arg: sl=%px, my_node=%px\n", sl, my_node);
+    int i;
+
+    nr_pages = max(ilog2(nr_pages), 1);
+    page = alloc_pages(GFP_KERNEL, max(ilog2(nr_pages), 1));
+    nr_pages = 1 << nr_pages;
+
+    array = page_address(page);
 
     arr_size = multi_skiplist_to_array(sl, array);
 #ifdef _SKIPLIST_API_DEBUG
@@ -61,16 +80,20 @@ static int f2fs_kv_flush_thread(void *arg) {
     }
 #endif
 
-    // Post array pointer & get block address
-    //   ...
-    blk_addr = (void *)0xdeadbeef;
+#ifdef _SKIPLIST_API_F2FS
+    f2fs_kv_flush(sbi, array, nr_pages, &blkaddr);
+#else
+    blkaddr = (void *)0xdeadbeef;
+#endif
 
     // Add BlockAddressNode to the global linked list's head
     node = (BlockAddressNode *)kmalloc(sizeof(BlockAddressNode), GFP_KERNEL);
-    node->block_address = blk_addr;
+    node->block_address = (void *) blkaddr;
     node->size = arr_size;
     node->prev = NULL;
     
+    trace_printk("KV flushed to blkaddr=0x%x\n", blkaddr);
+
     if(flushed_head != NULL) {
         node->next = flushed_head;
         flushed_head->prev = node;
@@ -84,22 +107,22 @@ static int f2fs_kv_flush_thread(void *arg) {
     kfree(array);
 
     // Stop finished threads
-    my_node->is_done = true;
-    tnode_it = my_node->next;
-    while(tnode_it != NULL) {
-        if(tnode_it->is_done) {
-            kthread_stop(tnode_it->task);
-            my_node->next = tnode_it->next;
-            kfree(tnode_it);
-        } else { // Thread not done
-            tnode_it->prev = my_node;
-            break;
-        }
-        tnode_it = my_node->next;
-    }
-    my_node->next = tnode_it;
+    // my_node->is_done = true;
+    // tnode_it = my_node->next;
+    // while(tnode_it != NULL) {
+    //     if(tnode_it->is_done) {
+    //         kthread_stop(tnode_it->task);
+    //         my_node->next = tnode_it->next;
+    //         kfree(tnode_it);
+    //     } else { // Thread not done
+    //         tnode_it->prev = my_node;
+    //         break;
+    //     }
+    //     tnode_it = my_node->next;
+    // }
+    // my_node->next = tnode_it;
     
-    // printk("Flush thread end\n");
+    printk("Flush thread end\n");
     return 0;
 }
 
@@ -123,6 +146,7 @@ int f2fs_kv_init(const int level_count) {
     if(result == 0) {
 #ifdef _SKIPLIST_API_DEBUG
         printk("Skiplist | Initialized.\n");
+        printk("sl: %px, top: %px\n", global_skiplist, global_skiplist->top);
 #endif
     } else {
 #ifdef _SKIPLIST_API_DEBUG
@@ -134,6 +158,12 @@ int f2fs_kv_init(const int level_count) {
 }
 EXPORT_SYMBOL(f2fs_kv_init);
 
+int f2fs_kv_init_sbi(const int level_count, void *_sbi)
+{
+	sbi = _sbi;
+	return f2fs_kv_init(level_count);
+}
+
 
 F2FS_NAT_Entry f2fs_kv_get(__u32 node_id) {
     Skiplist_Entry entry = {0, {0,0,0}};
@@ -141,6 +171,10 @@ F2FS_NAT_Entry f2fs_kv_get(__u32 node_id) {
     int i;
     BlockAddressNode *it;
     bool is_found = false;
+#ifdef _SKIPLIST_API_F2FS
+    struct page *page;
+    Skiplist_Entry *e;
+#endif
 
     entry.nid = node_id;
     ret = multi_skiplist_find(global_skiplist, (void *)(&entry));
@@ -156,9 +190,16 @@ F2FS_NAT_Entry f2fs_kv_get(__u32 node_id) {
 #ifdef _SKIPLIST_API_DEBUG
             printk("Skiplist | Try to read block_addr %px\n", it->block_address);
 #endif
-            blk_buf = 0; // Read from block address here...
+#ifdef _SKIPLIST_API_F2FS
+            page = alloc_pages(GFP_KERNEL, 0);
+            f2fs_kv_read(page, sbi, it->block_address);
+            blk_buf = page_address(page);
+            e = blk_buf;
+#else
+            blk_buf = 0;
 
             if(blk_buf != 0)
+#endif
             for(i=0; i<(it->size/sizeof(Skiplist_Entry)); i++) {
                 if(((Skiplist_Entry *)blk_buf)[i].nid == node_id) {
                     ret = (Skiplist_Entry *)blk_buf + i;
@@ -181,6 +222,7 @@ F2FS_NAT_Entry f2fs_kv_get(__u32 node_id) {
 
 #endif
 
+    kfree(blk_buf);
     trace_printk("KV GET: key=0x%x, value.version=%d, value.ino=0x%x, value.block_addr=0x%x\n",
 		    node_id, entry.nat_entry.version,
 		    entry.nat_entry.ino, entry.nat_entry.block_addr);
@@ -195,8 +237,8 @@ int f2fs_kv_put(__u32 node_id, F2FS_NAT_Entry entry) {
     int result = 0;
     void *ret;
 
-    ThreadNode *new_tnode;
-    ThreadArgs kth_args;
+    // ThreadNode *new_tnode;
+    // ThreadArgs *kth_args = (ThreadArgs *)kmalloc(sizeof(ThreadArgs), GFP_KERNEL);
     // NAT_Entry *entry = (NAT_Entry *)kmalloc(sizeof(NAT_Entry), GFP_KERNEL);
     // F2FS_NAT_Entry *entry = (F2FS_NAT_Entry *)kmalloc(sizeof(F2FS_NAT_Entry), GFP_KERNEL);
     Skiplist_Entry *s_entry = (Skiplist_Entry *)kmalloc(sizeof(Skiplist_Entry), GFP_KERNEL);
@@ -210,28 +252,35 @@ int f2fs_kv_put(__u32 node_id, F2FS_NAT_Entry entry) {
         // Check the list is immutable
         mutex_lock(&check_lock);
         if(cur_entry_num == IMMUTABLE_ENTRY_NUM) {
-            new_tnode = (ThreadNode *)kmalloc(sizeof(ThreadNode), GFP_KERNEL);
-            new_tnode->prev = NULL;
-            if(kthread_head == NULL) {
-                new_tnode->next = NULL;
-            } else {
-                kthread_head->prev = new_tnode;
-                new_tnode->next = kthread_head;
-            }
-            kthread_head = new_tnode;
+            // new_tnode = (ThreadNode *)kmalloc(sizeof(ThreadNode), GFP_KERNEL);
+            // printk("In mutex - net_tnode=%px\n", new_tnode);
+            // new_tnode->prev = NULL;
+            // if(kthread_head == NULL) {
+            //     new_tnode->next = NULL;
+            // } else {
+            //     kthread_head->prev = new_tnode;
+            //     new_tnode->next = kthread_head;
+            // }
+            // kthread_head = new_tnode;
 
-            kth_args.sl = global_skiplist;
-            kth_args.node = new_tnode;
-            new_tnode->task = kthread_run(f2fs_kv_flush_thread, &kth_args, "flush-thread-%d", flush_count);
+            // kth_args->sl = global_skiplist;
+            // kth_args->node = new_tnode;
+            // new_tnode->task = kthread_run(f2fs_kv_flush_thread, kth_args, "flush-thread-%d", flush_count);
+            kthread_run(f2fs_kv_flush_thread, global_skiplist, "flush-thread-%d", flush_count);
             flush_count++;
 #ifdef _SKIPLIST_API_DEBUG
-            if(new_tnode->task == ERR_PTR(-ENOMEM) || new_tnode->task == ERR_PTR(-EINTR))
-                printk(KERN_ERR "kthread_create() failed, flush-thread-%d\n", flush_count-1); 
+            // if(new_tnode->task == ERR_PTR(-ENOMEM) || new_tnode->task == ERR_PTR(-EINTR))
+            //     printk(KERN_ERR "kthread_create() failed, flush-thread-%d\n", flush_count-1); 
 #endif
 
             global_skiplist = (MultiSkiplist *)kmalloc(sizeof(MultiSkiplist), GFP_KERNEL);
             result = multi_skiplist_init(global_skiplist, sl_max_level, 
                 f2fs_kv_compare_func, f2fs_kv_free_func);
+            if(result != 0) {
+                printk(KERN_ERR "Global skiplist init. failed: %d\n", result);
+            } else {
+                printk("Global skiplist init. success, sl: %px, top: %px\n", global_skiplist, global_skiplist->top);
+            }
             cur_entry_num = 0;
         }
         cur_entry_num++;
@@ -266,14 +315,14 @@ EXPORT_SYMBOL(f2fs_kv_print);
 
 
 void f2fs_kv_destroy(void) {
-    ThreadNode *cur = kthread_head, *next;
+    // ThreadNode *cur = kthread_head, *next;
     BlockAddressNode *blk_cur = flushed_head, *blk_next;
-    while(cur != NULL) {
-        kthread_stop(cur->task);
-        next = cur->next;
-        kfree(cur);
-        cur = next;
-    }
+    // while(cur != NULL) {
+    //     kthread_stop(cur->task);
+    //     next = cur->next;
+    //     kfree(cur);
+    //     cur = next;
+    // }
     // TODO: save block addresses for next mount
     while(blk_cur != NULL) {
         blk_next = blk_cur->next;

--- a/skiplist_api.h
+++ b/skiplist_api.h
@@ -2,17 +2,18 @@
 #define _SKIPLIST_API_H
 
 #define _SKIPLIST_API_DEBUG // Debug flag
-// #define SKIPLIST_API_F2FS
+//#define _SKIPLIST_API_F2FS
 
 #include <linux/kernel.h>
 #include <linux/slab.h>
 #include <linux/kthread.h>
 #include <linux/types.h>
+#include <linux/mm.h>
 
 #include "multi_skiplist.h"
 #include "common_define.h"
 
-#ifdef SKIPLIST_API_F2FS
+#ifdef _SKIPLIST_API_F2FS
 #include <linux/f2fs_fs.h>
 #endif
 
@@ -22,7 +23,7 @@ typedef struct {
     void *blk_addr;
 }NAT_Entry;
 
-#ifndef SKIPLIST_API_F2FS
+#ifndef _SKIPLIST_API_F2FS
 struct f2fs_nat_entry {
     __u8 version;
     __u32 ino;
@@ -59,6 +60,7 @@ typedef struct _ThreadNode{
  * @return int, < 0 if failed.
  */
 int f2fs_kv_init(const int level_count);
+int f2fs_kv_init_sbi(const int level_count, void *_sbi);
 
 /**
  * @brief Destroy global skiplist.


### PR DESCRIPTION
While flushing current global skiplist, and get() request arrived, then get() might not be able to find requested data from neither current global skiplist and flushed block.
To resolve this, implemented pending skiplist manager. Get() can search on it if there're no other threads searching or add/remove entries in pending skiplist. If the target node found, it returns data which is not yet flushed.

Note that compaction of flushed data is not implemented yet.